### PR TITLE
Feature/testing deps

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,18 @@
+version: 0.1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        # Temporarily delete node_modules before building
+        - rm -rf node_modules
+        - yarn install
+    build:
+      commands:
+        - yarn build
+  artifacts:
+    baseDirectory: build
+    files:
+      - "**/*"
+  cache:
+    paths:
+      - node_modules/**/*


### PR DESCRIPTION
add's a yml file that ought to tell Amplify to wipe the node modules before the next build. 