### PR TITLE
removed toJSON function property that comes with error object in order to…

### DIFF
--- a/src/components/Auth/UserLogin.js
+++ b/src/components/Auth/UserLogin.js
@@ -90,7 +90,7 @@ function UserLogin(props) {
                             />
                         </fieldset>   */}
 
-                        {/* {(props.error === null ? <p></p> : <p className='input-errors'>{(props.error.response.data.message)}</p>)} */}
+                        {(props.error === null ? <p></p> : <p className='input-errors'>{(props.error.response.data.message)}</p>)}
 
                         <fieldset className="cardfieldset">  
                         <button className="card-button" type="submit">Log in</button>

--- a/src/components/Auth/UserSignUp.js
+++ b/src/components/Auth/UserSignUp.js
@@ -93,7 +93,7 @@ function UserSignUp(props) {
 
                         {/* <p>{(props.error == null ? '' : (props.error.response.data.errorMessage))}</p> */}
 
-                        {/* {(props.error == null ? <p> </p> : <p className='input-errors'>{(props.error.response.data.errorMessage)}</p> )} */}
+                        {(props.error == null ? <p> </p> : <p className='input-errors'>{(props.error.response.data.errorMessage)}</p> )}
 
                         <fieldset className="cardfieldset">
                             <button className="card-button" type="submit">Sign up</button>

--- a/src/views/private/reducers/reducer-user.js
+++ b/src/views/private/reducers/reducer-user.js
@@ -44,6 +44,7 @@ function reducer(state = initialState, action) {
         isFetching: false,
       };
     case SET_ERROR:
+      delete action.payload.toJSON
       return {
         ...state,
         error: action.payload,


### PR DESCRIPTION
… fix error state persisting bug

error state did not properly persist through refreshes. once stringified, the data that was stored to localStorage to persist data was different than the state stored to local state in redux. therefore, error messages worked before refresh, but if you refreshed when there was a current error on the screen, the data it would try to refrence upon refresh was different, and it couldn't find what it was looking for

deleted the toJSON function property that was on the error message that gets stored in state, since objects with a toJSON function property stringify differently. see documentation on developer.mozilla for .stringfy for more information on the cause