### PR TITLE
Carousel form - buttons for switching slides/metrics

### DIFF
--- a/src/components/DailyRetro/CarouselForm/slides/Breaks/BreaksQuestion.js
+++ b/src/components/DailyRetro/CarouselForm/slides/Breaks/BreaksQuestion.js
@@ -5,7 +5,9 @@ class BreaksQuestion extends React.Component{
   render() {
     return (
       <div>
+        <button onClick={this.props.previous}>{"<---------"}</button>
         <h3>How many breaks did you take today?</h3>
+        <button onClick={this.props.next}>{"--------->"}</button>
       </div>
     )
   }

--- a/src/components/DailyRetro/CarouselForm/slides/Breaks/BreaksSlide.js
+++ b/src/components/DailyRetro/CarouselForm/slides/Breaks/BreaksSlide.js
@@ -9,7 +9,7 @@ class BreaksSlide extends React.Component {
   render() {
     return (
       <div>
-        <BreaksQuestion />
+        <BreaksQuestion next={this.props.next} previous={this.props.previous} />
 
         <div>
           <BreaksCard />

--- a/src/components/DailyRetro/CarouselForm/slides/Exercise/ExerciseQuestion.js
+++ b/src/components/DailyRetro/CarouselForm/slides/Exercise/ExerciseQuestion.js
@@ -5,7 +5,9 @@ class ExerciseQuestion extends React.Component{
   render() {
     return (
       <div>
+        <button onClick={this.props.previous}>{"<---------"}</button>
         <h3>How much exercise did you get today?</h3>
+        <button onClick={this.props.next}>{"--------->"}</button>
       </div>
     )
   }

--- a/src/components/DailyRetro/CarouselForm/slides/Exercise/ExerciseSlide.js
+++ b/src/components/DailyRetro/CarouselForm/slides/Exercise/ExerciseSlide.js
@@ -9,7 +9,7 @@ class ExerciseSlide extends React.Component {
   render() {
     return (
       <div>
-        <ExerciseQuestion />
+        <ExerciseQuestion next={this.props.next} previous={this.props.previous} />
 
         <div>
           <ExerciseCard />

--- a/src/components/DailyRetro/CarouselForm/slides/Sleep/SleepQuestion.js
+++ b/src/components/DailyRetro/CarouselForm/slides/Sleep/SleepQuestion.js
@@ -5,7 +5,9 @@ class SleepQuestion extends React.Component{
   render() {
     return (
       <div>
+        <button onClick={this.props.previous}>{"<---------"}</button>
         <h3>How did you sleep last night?</h3>
+        <button onClick={this.props.next}>{"--------->"}</button>
       </div>
     )
   }

--- a/src/components/DailyRetro/CarouselForm/slides/Sleep/SleepSlide.js
+++ b/src/components/DailyRetro/CarouselForm/slides/Sleep/SleepSlide.js
@@ -10,7 +10,7 @@ class SleepSlide extends React.Component {
   render() {
     return (
       <div>
-        <SleepQuestion />
+        <SleepQuestion next={this.props.next} previous={this.props.previous}/>
 
         <div>
           <SleepCard />

--- a/src/components/DailyRetro/CarouselForm/slides/Water/WaterQuestion.js
+++ b/src/components/DailyRetro/CarouselForm/slides/Water/WaterQuestion.js
@@ -5,7 +5,9 @@ class WaterQuestion extends React.Component{
   render() {
     return (
       <div>
+        <button onClick={this.props.previous}>{"<---------"}</button>
         <h3>How much water did you drink?</h3>
+        <button onClick={this.props.next}>{"--------->"}</button>
       </div>
     )
   }

--- a/src/components/DailyRetro/CarouselForm/slides/Water/WaterSlide.js
+++ b/src/components/DailyRetro/CarouselForm/slides/Water/WaterSlide.js
@@ -10,7 +10,7 @@ class WaterSlide extends React.Component {
   render() {
     return (
       <div>
-        <WaterQuestion />
+        <WaterQuestion next={this.props.next} previous={this.props.previous} />
 
         <div>
           <WaterCard />

--- a/src/components/DailyRetro/Form/Form.js
+++ b/src/components/DailyRetro/Form/Form.js
@@ -5,26 +5,9 @@ import SleepSlide from "../CarouselForm/slides/Sleep/SleepSlide.js";
 import BreaksSlide from "../CarouselForm/slides/Breaks/BreaksSlide.js";
 import {
   Carousel,
-  CarouselItem,
-  CarouselControl,
-  CarouselIndicators,
+  CarouselItem
 } from "reactstrap";
 
-//in documentation, items are in an object form? may need to change if we have any trouble
-const items = [
-  {
-    src: <WaterSlide />,
-  },
-  {
-    src: <ExerciseSlide />,
-  },
-  {
-    src: <SleepSlide />,
-  },
-  {
-    src: <BreaksSlide />,
-  },
-];
 
 function Form(props) {
   const [activeIndex, setActiveIndex] = useState(0);
@@ -56,6 +39,22 @@ function Form(props) {
     setActiveIndex(newIndex);
   };
 
+  //in documentation, items are in an object form? may need to change if we have any trouble
+  const items = [
+  {
+    src: <WaterSlide next={next} previous={previous}/>,
+  },
+  {
+    src: <ExerciseSlide next={next} previous={previous}/>,
+  },
+  {
+    src: <SleepSlide next={next} previous={previous}/>,
+  },
+  {
+    src: <BreaksSlide next={next} previous={previous}/>,
+  },
+];
+
   const slides = items.map((item, index) => {
     return (
       <CarouselItem
@@ -78,18 +77,7 @@ function Form(props) {
         // slide={false}
       >
         {slides}
-        <CarouselControl
-          direction="prev"
-          directionText="Previous"
-          onClickHandler={previous}
-          key="prev"
-        />
-        <CarouselControl
-          direction="next"
-          directionText="Next"
-          onClickHandler={next}
-          key="next"
-        />
+    
       </Carousel>
     </div>
   );


### PR DESCRIPTION
Customized the methods of switching between metric slides on the carousel. The next/previous functions that control activeIndex state are passed down as props to each metric slide, then passed again as props down to each metric question slide where the arrow buttons are located. onClick of these arrow buttons call the next and previous functions accordingly