### PR TITLE
leaderboard points now update accordingly when a user changes teams

### DIFF
--- a/src/views/private/actions/actions.js
+++ b/src/views/private/actions/actions.js
@@ -71,7 +71,6 @@ export const updateUserTeam = (userId, editedTeamId, oldTeamId, usersPoints) => 
   axios
     .put(`https://lab23-refresh-be.herokuapp.com/users/${userId}`, editedTeamId)
     .then((response) => {
-      console.log("updateUserTeam response: ", response);
       dispatch({ type: UPDATE_USER_TEAM_SUCCESS, payload: response.data });
 
       //if update succeeds, then update old and new team's points on backend and front end
@@ -86,11 +85,7 @@ export const updateUserTeam = (userId, editedTeamId, oldTeamId, usersPoints) => 
           axios
             .put(`https://lab23-refresh-be.herokuapp.com/teams/${oldTeamId}`, {points: (oldTeamTotalPoints - usersPoints)})
             .then((response) => {
-        
-              console.log("RESPONSE AFTER UPDATING OLD TEAMS POINTS: ", response)
-        
-              //!!!!!!!!!! need to connect this to the reducer
-              dispatch({ type: UPDATE_TEAM_POINTS, payload: {team: oldTeamId, points: (oldTeamTotalPoints - usersPoints)} });
+              dispatch({ type: UPDATE_TEAM_POINTS, payload: {teamId: oldTeamId, points: (oldTeamTotalPoints - usersPoints)} });
         
               //then update new team's points, backend and front end
               //first GET existing total points of new team, in order to use when adjusting the teams total points due to user changing teams
@@ -103,12 +98,7 @@ export const updateUserTeam = (userId, editedTeamId, oldTeamId, usersPoints) => 
                 axios
                 .put(`https://lab23-refresh-be.herokuapp.com/teams/${editedTeamId.team_id}`, {points: (newTeamTotalPoints + usersPoints)})
                 .then((response) => {
-                  
-                  console.log("RESPONSE AFTER UPDATING NEW TEAMS POINTS: ", response)
-          
-                  //!!!!!!!!!! need to connect this to the reducer
-                  dispatch({ type: UPDATE_TEAM_POINTS, payload: {team: editedTeamId.team_id, points: (newTeamTotalPoints + usersPoints)} });
-          
+                  dispatch({ type: UPDATE_TEAM_POINTS, payload: {teamId: parseInt(editedTeamId.team_id), points: (newTeamTotalPoints + usersPoints)} });
                 })
                 .catch((error) => {
                   console.log("Error when updating new team's points", error)
@@ -194,18 +184,6 @@ export const editTeamName = (teamId, editedTeamName) => (dispatch) => {
       dispatch({ type: UPDATE_TEAM_NAME_FAILURE, payload: error })
     );
 };
-
-// export const updateTeamPoints = (teamId) => (dispatch) => {
-//   dispatch({ type: UPDATE_USER_TEAM_START });
-//   axios
-//     .put(`https://lab23-refresh-be.herokuapp.com/teams/${teamId}`)
-//     .then((response) => {
-//       dispatch({ type: UPDATE_TEAM_POINTS, payload: response.data });
-//     })
-//     .catch((error) => {
-//       dispatch({ type: UPDATE_USER_TEAM_FAILURE, PAYLOAD: error });
-//     }); 
-// };
 
 export const adminLogin = (credentials) => (dispatch) => {
   dispatch({ type: FETCH_USER_LOADING });

--- a/src/views/private/actions/actions.js
+++ b/src/views/private/actions/actions.js
@@ -66,13 +66,62 @@ export const fetchUserTeamName = (userId) => (dispatch) => {
     );
 };
 
-export const updateUserTeam = (userId, editedTeamId) => (dispatch) => {
+export const updateUserTeam = (userId, editedTeamId, oldTeamId, usersPoints) => (dispatch) => {
   dispatch({ type: UPDATE_USER_TEAM_START });
   axios
     .put(`https://lab23-refresh-be.herokuapp.com/users/${userId}`, editedTeamId)
     .then((response) => {
       console.log("updateUserTeam response: ", response);
       dispatch({ type: UPDATE_USER_TEAM_SUCCESS, payload: response.data });
+
+      //if update succeeds, then update old and new team's points on backend and front end
+
+      //first GET existing total points of old team, in order to use when adjusting the team's total points due to user changing teams
+      axios
+        .get(`https://lab23-refresh-be.herokuapp.com/teams/${oldTeamId}`)
+        .then(response => {
+          const oldTeamTotalPoints = response.data.points
+
+          //update old team's points
+          axios
+            .put(`https://lab23-refresh-be.herokuapp.com/teams/${oldTeamId}`, {points: (oldTeamTotalPoints - usersPoints)})
+            .then((response) => {
+        
+              console.log("RESPONSE AFTER UPDATING OLD TEAMS POINTS: ", response)
+        
+              //!!!!!!!!!! need to connect this to the reducer
+              dispatch({ type: UPDATE_TEAM_POINTS, payload: {team: oldTeamId, points: (oldTeamTotalPoints - usersPoints)} });
+        
+              //then update new team's points, backend and front end
+              //first GET existing total points of new team, in order to use when adjusting the teams total points due to user changing teams
+              axios
+              .get(`https://lab23-refresh-be.herokuapp.com/teams/${editedTeamId.team_id}`)
+              .then((response => {
+                const newTeamTotalPoints = response.data.points
+
+                //update new team's points
+                axios
+                .put(`https://lab23-refresh-be.herokuapp.com/teams/${editedTeamId.team_id}`, {points: (newTeamTotalPoints + usersPoints)})
+                .then((response) => {
+                  
+                  console.log("RESPONSE AFTER UPDATING NEW TEAMS POINTS: ", response)
+          
+                  //!!!!!!!!!! need to connect this to the reducer
+                  dispatch({ type: UPDATE_TEAM_POINTS, payload: {team: editedTeamId.team_id, points: (newTeamTotalPoints + usersPoints)} });
+          
+                })
+                .catch((error) => {
+                  console.log("Error when updating new team's points", error)
+                });
+              }))
+            
+            })
+            .catch((error) => {
+              console.log("Error when updating team's points", error)
+            });
+
+        })
+
     })
     .catch((error) =>
       dispatch({ type: UPDATE_USER_TEAM_FAILURE, payload: error })
@@ -146,17 +195,17 @@ export const editTeamName = (teamId, editedTeamName) => (dispatch) => {
     );
 };
 
-export const updateTeamPoints = (teamId) => (dispatch) => {
-  dispatch({ type: UPDATE_USER_TEAM_START });
-  axios
-    .put(`https://lab23-refresh-be.herokuapp.com/teams/${teamId}`)
-    .then((response) => {
-      dispatch({ type: UPDATE_TEAM_POINTS, payload: response.data });
-    })
-    .catch((error) => {
-      dispatch({ type: UPDATE_USER_TEAM_FAILURE, PAYLOAD: error });
-    });
-};
+// export const updateTeamPoints = (teamId) => (dispatch) => {
+//   dispatch({ type: UPDATE_USER_TEAM_START });
+//   axios
+//     .put(`https://lab23-refresh-be.herokuapp.com/teams/${teamId}`)
+//     .then((response) => {
+//       dispatch({ type: UPDATE_TEAM_POINTS, payload: response.data });
+//     })
+//     .catch((error) => {
+//       dispatch({ type: UPDATE_USER_TEAM_FAILURE, PAYLOAD: error });
+//     }); 
+// };
 
 export const adminLogin = (credentials) => (dispatch) => {
   dispatch({ type: FETCH_USER_LOADING });

--- a/src/views/private/reducers/reducers.js
+++ b/src/views/private/reducers/reducers.js
@@ -168,21 +168,21 @@ function reducer(state = initialState, action) {
         error: action.payload,
       };
 
-    case UPDATE_TEAM_POINTS:
-      return {
-        ...state,
-        isFetching: false,
-        teams: [
-          ...state.teams,
-        //   TODO: Update the team points
+    // case UPDATE_TEAM_POINTS:
+    //   return {
+    //     ...state,
+    //     isFetching: false,
+    //     teams: [
+    //       ...state.teams,
+    //     //   TODO: Update the team points
 
-          state.teams.map((team) => {
-            if (team.id === action.payload.id) {
-              team.points = action.payload.points;
-            }
-          }),
-        ],
-      };
+    //       state.teams.map((team) => {
+    //         if (team.id === action.payload.id) {
+    //           team.points = action.payload.points;
+    //         }
+    //       }),
+    //     ],
+    //   };
 
     default:
       return state;

--- a/src/views/private/reducers/reducers.js
+++ b/src/views/private/reducers/reducers.js
@@ -168,21 +168,19 @@ function reducer(state = initialState, action) {
         error: action.payload,
       };
 
-    // case UPDATE_TEAM_POINTS:
-    //   return {
-    //     ...state,
-    //     isFetching: false,
-    //     teams: [
-    //       ...state.teams,
-    //     //   TODO: Update the team points
-
-    //       state.teams.map((team) => {
-    //         if (team.id === action.payload.id) {
-    //           team.points = action.payload.points;
-    //         }
-    //       }),
-    //     ],
-    //   };
+    case UPDATE_TEAM_POINTS:
+      return {
+        ...state,
+        isFetching: false,
+        teams: [
+          ...state.teams,
+          state.teams.map((team) => {
+            if (team.id === action.payload.teamId) {
+              team.points = action.payload.points;
+            }
+          }),
+        ],
+      };
 
     default:
       return state;

--- a/src/views/private/user-list/user-card.js
+++ b/src/views/private/user-list/user-card.js
@@ -10,11 +10,12 @@ const UserCard = props => {
         props.routeToUserProfile(props.info.id)
     }
 
-    const handleSubmit = event => {
+    const handleSubmit = (oldTeamID, totalPoints) => event => {
+        
         let editedTeam = { team_id: event.target.value }
         event.preventDefault();
         if(editedTeam) {
-            props.updateUserTeam(props.info.id, editedTeam)
+            props.updateUserTeam(props.info.id, editedTeam, oldTeamID, totalPoints)
             setTimeout(() => {props.rerender(!props.update)}, 100)
         } 
     }
@@ -41,7 +42,7 @@ const UserCard = props => {
                     {`${props.info.total_points === null ? props.info.total_points = 0 : props.info.total_points} POINTS`}
                 </h2>
                 </Blue>
-                <Dropdown onChange={handleSubmit}>
+                <Dropdown onChange={handleSubmit(props.info.team_id, props.info.total_points)}>
                     <option>
                         {`${props.info.name === null ? props.info.name = 'None' : props.info.name}`}
                     </option>


### PR DESCRIPTION
added functionality to the existing updateUserTeam action in actions.js that is called when a user changes teams (in user-card.js). Now, when user changes teams, both the old team and the new team's points are adjusted on the back end accordingly.

still need to set up dispatch in reducer to update redux state for team points changes. However, this does not change affect the functionality for the app currently, just should make these changes for consistency