### PR TITLE
fixed bug where once new users are assigned to a team, existing point…

### DIFF
--- a/src/views/private/actions/actions.js
+++ b/src/views/private/actions/actions.js
@@ -76,41 +76,42 @@ export const updateUserTeam = (userId, editedTeamId, oldTeamId, usersPoints) => 
       //if update succeeds, then update old and new team's points on backend and front end
 
       //first GET existing total points of old team, in order to use when adjusting the team's total points due to user changing teams
+      //check to make sure oldTeamId isn't null (as it would be if it were a fresh user not yet assigned to a team)
+      if (oldTeamId !== null) {
+        axios
+          .get(`https://lab23-refresh-be.herokuapp.com/teams/${oldTeamId}`)
+          .then(response => {
+            const oldTeamTotalPoints = response.data.points
+
+            //update old team's points
+            axios
+              .put(`https://lab23-refresh-be.herokuapp.com/teams/${oldTeamId}`, {points: (oldTeamTotalPoints - usersPoints)})
+              .then((response) => {
+                dispatch({ type: UPDATE_TEAM_POINTS, payload: {teamId: oldTeamId, points: (oldTeamTotalPoints - usersPoints)} });
+              })
+              .catch((error) => {
+                console.log("Error when updating team's points", error)
+              });
+          })
+      }
+
+      //then update new team's points, backend and front end
+      //first GET existing total points of new team, in order to use when adjusting the teams total points due to user changing teams
       axios
-        .get(`https://lab23-refresh-be.herokuapp.com/teams/${oldTeamId}`)
-        .then(response => {
-          const oldTeamTotalPoints = response.data.points
+      .get(`https://lab23-refresh-be.herokuapp.com/teams/${editedTeamId.team_id}`)
+      .then((response => {
+        const newTeamTotalPoints = response.data.points
 
-          //update old team's points
-          axios
-            .put(`https://lab23-refresh-be.herokuapp.com/teams/${oldTeamId}`, {points: (oldTeamTotalPoints - usersPoints)})
-            .then((response) => {
-              dispatch({ type: UPDATE_TEAM_POINTS, payload: {teamId: oldTeamId, points: (oldTeamTotalPoints - usersPoints)} });
-        
-              //then update new team's points, backend and front end
-              //first GET existing total points of new team, in order to use when adjusting the teams total points due to user changing teams
-              axios
-              .get(`https://lab23-refresh-be.herokuapp.com/teams/${editedTeamId.team_id}`)
-              .then((response => {
-                const newTeamTotalPoints = response.data.points
-
-                //update new team's points
-                axios
-                .put(`https://lab23-refresh-be.herokuapp.com/teams/${editedTeamId.team_id}`, {points: (newTeamTotalPoints + usersPoints)})
-                .then((response) => {
-                  dispatch({ type: UPDATE_TEAM_POINTS, payload: {teamId: parseInt(editedTeamId.team_id), points: (newTeamTotalPoints + usersPoints)} });
-                })
-                .catch((error) => {
-                  console.log("Error when updating new team's points", error)
-                });
-              }))
-            
-            })
-            .catch((error) => {
-              console.log("Error when updating team's points", error)
-            });
-
+        //update new team's points
+        axios
+        .put(`https://lab23-refresh-be.herokuapp.com/teams/${editedTeamId.team_id}`, {points: (newTeamTotalPoints + usersPoints)})
+        .then((response) => {
+          dispatch({ type: UPDATE_TEAM_POINTS, payload: {teamId: parseInt(editedTeamId.team_id), points: (newTeamTotalPoints + usersPoints)} });
         })
+        .catch((error) => {
+          console.log("Error when updating new team's points", error)
+        });
+      }))
 
     })
     .catch((error) =>


### PR DESCRIPTION
…s for that user are now added to designated team points

moved around axios calls, so that even if users don't have an assigned team, new team points can still be updated. Previously, that axios PUT request couldnt be hit as it was nested inside updating the old team axios call, which won't be hit in the case of a brand new user, as they had no previous team.