### PR TITLE
fixed displaying errors on the login component, errors for admin login attempts are now displayed

### DIFF
--- a/src/components/Auth/UserLogin.js
+++ b/src/components/Auth/UserLogin.js
@@ -1,11 +1,13 @@
 import React from "react";
 import {Link} from 'react-router-dom';
 import {useForm} from 'react-hook-form';
-import {login} from '../../views/private/actions/actions-user';
-import {adminLogin} from '../../views/private/actions/actions';
+import {login, clearErrorUser} from '../../views/private/actions/actions-user';
+import {adminLogin, clearErrorAdmin} from '../../views/private/actions/actions';
 import {connect} from 'react-redux';
 import Marketing from './Marketing'
 
+
+//login component for BOTH user types - users and admins
 function UserLogin(props) {
 
     //adjusted the 'mode' argument from the default value of 'onSubmit' for the useForm hook, in order to allow live error changes as user types
@@ -14,6 +16,12 @@ function UserLogin(props) {
     //handle form submit
     const submitForm = (data, event) => {
         //event.preventDefault();
+
+        //first clear any error data that could have previously existed (such as from a previous invalid login try)
+        //this way, if users try logging in as a user but meant to as admin, but still fail on the 2nd attempt at logging in as an admin,
+        //users only sees the error associated with the last attempt
+        props.clearErrorUser();
+        props.clearErrorAdmin();
 
         //send data of user object with email/password through to login action
         const user = {
@@ -24,14 +32,10 @@ function UserLogin(props) {
         //check if user logging in checked if they were an administrator or not, then direct to proper login
         if (data.admin) {
             props.adminLogin(user);
-            console.log("hit admin login")
         }
         else {
             props.login(user); 
-            console.log("hit user login")
         }
-
-
     }
 
     return (
@@ -102,6 +106,8 @@ function UserLogin(props) {
 
                         {(props.error === null ? <p></p> : <p className='input-errors'>{(props.error.response.data.message)}</p>)}
 
+                        {(props.adminError === null ? <p></p> : <p className='input-errors'>{(props.adminError.response.data.message)}</p>)}
+
                         <fieldset className="cardfieldset">  
                         <button className="card-button" type="submit">Log in</button>
                         </fieldset>
@@ -119,8 +125,9 @@ function UserLogin(props) {
 
 const mapStateToProps = state => {
     return {
-        error: state.userReducer.error
+        error: state.userReducer.error,
+        adminError: state.reducer.error
     }
 }
 
-export default connect(mapStateToProps, {login, adminLogin})(UserLogin)
+export default connect(mapStateToProps, {login, adminLogin, clearErrorAdmin, clearErrorUser})(UserLogin)

--- a/src/views/private/actions/actions-user.js
+++ b/src/views/private/actions/actions-user.js
@@ -12,6 +12,7 @@ export const UPDATE_SLEEP = "UPDATE_SLEEP";
 export const UPDATE_EXERCISE = "UPDATE_EXERCISE";
 export const UPDATE_BREAKS = "UPDATE_BREAKS";
 export const UPDATE_POINTS = "UPDATE_POINTS";
+export const CLEAR_ERROR = "CLEAR_ERROR";
 
 export const UPDATE_TEAM_POINTS = "UPDATE_TEAM_POINTS";
 export const UPDATE_USER_TEAM_FAILURE = "UPDATE_USER_TEAM_FAILURE";
@@ -733,6 +734,13 @@ export const subtractBreaks = (
     dispatch({ type: UPDATE_USER_TEAM_FAILURE, payload: error });
   });
 };
+
+export const clearErrorUser = () => (dispatch) => {
+  dispatch({ type: CLEAR_ERROR });
+}
+
+
+
 
 //update points for sleep helper function
 function updatePointsSleep(metricNum, goal, operation) {

--- a/src/views/private/actions/actions.js
+++ b/src/views/private/actions/actions.js
@@ -40,6 +40,8 @@ export const UPDATE_TEAM_NAME_SUCCESS = "UPDATE_TEAM_NAME_SUCCESS";
 export const UPDATE_TEAM_NAME_FAILURE = "UPDATE_TEAM_NAME_FAILURE";
 export const UPDATE_TEAM_POINTS = "UPDATE_TEAM_POINTS";
 
+export const CLEAR_ERROR = "CLEAR_ERROR"
+
 // Async Action Creators
 export const fetchAllUsers = () => (dispatch) => {
   dispatch({ type: FETCH_ALL_USERS_LOADING });
@@ -204,4 +206,8 @@ export const adminLogin = (credentials) => (dispatch) => {
     console.log(err)
     dispatch({type: FETCH_USER_FAILURE, payload: err})
   });
+}
+
+export const clearErrorAdmin = () => (dispatch) => {
+  dispatch({ type: CLEAR_ERROR });
 }

--- a/src/views/private/reducers/reducer-user.js
+++ b/src/views/private/reducers/reducer-user.js
@@ -9,6 +9,7 @@ import {
   UPDATE_EXERCISE,
   UPDATE_BREAKS,
   UPDATE_POINTS,
+  CLEAR_ERROR
 } from "../actions/actions-user.js";
 
 const initialState = {
@@ -118,6 +119,12 @@ function reducer(state = initialState, action) {
         totalPoints: state.totalPoints + action.payload,
       };
     }
+    case CLEAR_ERROR: 
+    return {
+      ...state, 
+      error: null
+    };
+
     default:
       return state;
   }

--- a/src/views/private/reducers/reducers.js
+++ b/src/views/private/reducers/reducers.js
@@ -26,7 +26,8 @@ import {
   UPDATE_TEAM_NAME_START,
   UPDATE_TEAM_NAME_SUCCESS,
   UPDATE_TEAM_NAME_FAILURE,
-  UPDATE_TEAM_POINTS
+  UPDATE_TEAM_POINTS,
+  CLEAR_ERROR
 } from "../actions/actions";
 
 const initialState = {
@@ -94,6 +95,7 @@ function reducer(state = initialState, action) {
         singleUser: action.payload,
       };
     case FETCH_USER_FAILURE:
+      delete action.payload.toJSON
       return {
         ...state,
         error: action.payload,
@@ -180,6 +182,12 @@ function reducer(state = initialState, action) {
             }
           }),
         ],
+      };
+    
+    case CLEAR_ERROR: 
+      return {
+        ...state, 
+        error: null
       };
 
     default:


### PR DESCRIPTION
added the error state from reducer.js to the UserLogin, to display errors from failed attempts at admin logins. 

added an action and dispatch for each reducer (reducer and userReducer), so that we can clear error state upon submitting the form. This way, users only see the error associated with the last login attempt they made. 

This fix accounts for multiple failed login attempts. For example, if a user was trying to login as an admin, but didn't hit the admin checkbox before submitting. An error invalid creds shows up, coming from error state from userReducer.js. Then, say the user clicks the checkbox, and tries again, but the password was wrong. Then an error from the reducer.js would show up from the invalid admin login attempt, but the error state from the first attempt is still there, so it is shown as well. Deleting any previous error states first thing after submitting the form fixes this issue. 